### PR TITLE
Add goroutine for ping on Connect()

### DIFF
--- a/bybit_websocket.go
+++ b/bybit_websocket.go
@@ -137,7 +137,7 @@ func (b *WebSocket) Connect() *WebSocket {
 	go b.monitorConnection()
 
 	b.ctx, b.cancel = context.WithCancel(context.Background())
-	ping(b)
+	go ping(b)
 
 	return b
 }


### PR DESCRIPTION
Without the goroutine, the call to ping() was taking control of the execution flow.