### PR TITLE
Fix: Corrected WebSocket demo URLs by removing redundant "wss://" prefix

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -26,8 +26,8 @@ const (
 	WEBSOCKET_TRADE_MAINNET   = "wss://stream.bybit.com/v5/trade"
 	WEBSOCKET_PRIVATE_TESTNET = "wss://stream-testnet.bybit.com/v5/private"
 	WEBSOCKET_TRADE_TESTNET   = "wss://stream-testnet.bybit.com/v5/trade"
-	WEBSOCKET_PRIVATE_DEMO    = "wss://wss://stream-demo.bybit.com/v5/private"
-	WEBSOCKET_TRADE_DEMO      = "wss://wss://stream-demo.bybit.com/v5/trade"
+	WEBSOCKET_PRIVATE_DEMO    = "wss://stream-demo.bybit.com/v5/private"
+	WEBSOCKET_TRADE_DEMO      = "wss://stream-demo.bybit.com/v5/trade"
 
 	// Deprecated: V3 is deprecated and replaced by v5
 	V3_CONTRACT_PRIVATE = "wss://stream.bybit.com/contract/private/v3"


### PR DESCRIPTION
The WebSocket URLs for private and trade demo endpoints contained an extra "wss://" prefix, causing connection issues. This commit resolves the issue by updating the URLs to the correct format.